### PR TITLE
Global plugin state

### DIFF
--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -264,7 +264,6 @@ class QPluginList(QListWidget):
             plugin_name=plugin_name,
             enabled=enabled,
         )
-
         method = getattr(
             self.installer, 'uninstall' if plugin_name else 'install'
         )
@@ -339,7 +338,6 @@ class QtPluginDialog(QDialog):
                 meta = standard_metadata(distname)
             else:
                 meta = {}
-
             self.installed_list.addItem(
                 ProjectInfo(
                     normalized_name(distname or ''),

--- a/napari/_qt/dialogs/qt_plugin_dialog.py
+++ b/napari/_qt/dialogs/qt_plugin_dialog.py
@@ -237,9 +237,6 @@ class PluginListItem(QFrame):
     def _on_enabled_checkbox(self, state: int):
         """Called with `state` when checkbox is clicked."""
         plugin_manager.set_blocked(self.plugin_name.text(), not state)
-        if state:
-            print('discover!')
-            plugin_manager.discover()
 
 
 class QPluginList(QListWidget):

--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -369,8 +369,12 @@ class Window:
 
         SETTINGS.appearance.events.theme.connect(self._update_theme)
 
-        plugin_manager.events.disabled.connect(self._update_menus)
-        plugin_manager.events.enabled.connect(self._update_menus)
+        plugin_manager.events.disabled.connect(self._rebuild_dock_widget_menu)
+        plugin_manager.events.disabled.connect(self._rebuild_samples_menu)
+        plugin_manager.events.registered.connect(
+            self._rebuild_dock_widget_menu
+        )
+        plugin_manager.events.registered.connect(self._rebuild_samples_menu)
 
         viewer.events.status.connect(self._status_changed)
         viewer.events.help.connect(self._help_changed)
@@ -502,7 +506,7 @@ class Window:
         plugin_manager.discover_sample_data()
         self.open_sample_menu = QMenu(trans._('Open Sample'), self._qt_window)
 
-        self._fill_sample_menu()
+        self._rebuild_samples_menu()
 
         self.file_menu = self.main_menu.addMenu(trans._('&File'))
         self.file_menu.addAction(open_images)
@@ -524,7 +528,8 @@ class Window:
 
         self.file_menu.addAction(quitAction)
 
-    def _fill_sample_menu(self):
+    def _rebuild_samples_menu(self, event=None):
+        self.open_sample_menu.clear()
 
         for plugin_name, samples in plugin_manager._sample_data.items():
             multiprovider = len(samples) > 1
@@ -756,15 +761,16 @@ class Window:
         )
 
         plugin_manager.discover_widgets()
-        self._fill_dock_widget_menu()
+        self._rebuild_dock_widget_menu()
 
         self.plugins_menu.addMenu(self._plugin_dock_widget_menu)
 
-    def _fill_dock_widget_menu(self):
+    def _rebuild_dock_widget_menu(self, event=None):
+
+        self._plugin_dock_widget_menu.clear()
 
         # Add a menu item (QAction) for each available plugin widget
         for hook_type, (plugin_name, widgets) in plugin_manager.iter_widgets():
-            print(plugin_name)
             multiprovider = len(widgets) > 1
             if multiprovider:
                 menu = QMenu(plugin_name, self._qt_window)
@@ -792,22 +798,8 @@ class Window:
     def _show_plugin_install_dialog(self):
         """Show dialog that allows users to sort the call order of plugins."""
 
-        self.plugin_dialog = QtPluginDialog(
-            self._qt_window, copy.deepcopy(SETTINGS.plugins.disabled_plugins)
-        )
-        # self.plugin_dialog.on_changed.connect(self._update_menus)
+        self.plugin_dialog = QtPluginDialog(self._qt_window)
         self.plugin_dialog.exec_()
-
-    def _update_menus(self, event):
-        """"Update dock widget and sample menus when plugins are enabled/disabled."""
-
-        # does not update menus properly.  not sure how to get the same plugin manager
-        print('supposed to update menu')
-        self._plugin_dock_widget_menu.clear()
-        self._fill_dock_widget_menu()
-
-        self.open_sample_menu.clear()
-        self._fill_sample_menu()
 
     def _show_plugin_err_reporter(self):
         """Show dialog that allows users to review and report plugin errors."""

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -300,9 +300,8 @@ class QtPluginSorter(QWidget):
         self.hook_combo_box = QComboBox()
         self.hook_combo_box.addItem(self.NULL_OPTION, None)
 
-        # Included this, because I believe we want the plugin sorter to update from listening.
         self.plugin_manager.events.disabled.connect(self._on_disabled)
-        # self.plugin_manager.events.enabled.connect(self._update)
+        self.plugin_manager.events.registered.connect(self.refresh)
 
         # populate comboBox with all of the hooks known by the plugin manager
 
@@ -395,11 +394,12 @@ class QtPluginSorter(QWidget):
             self.info.hide()
             self.docstring.setToolTip('')
 
-    def refresh(self, event=None):
+    def refresh(self):
+        print("refresh", self.hook_combo_box.currentIndex())
         self._on_hook_change(self.hook_combo_box.currentIndex())
 
     def _on_disabled(self, event):
-        for i in range(self.hook_list.count()):
+        for i in range(self.hook_list.count() - 1):
             item = self.hook_list.item(i)
             if item.hook_implementation.plugin_name == event.value:
                 self.hook_list.takeItem(i)

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -394,14 +394,13 @@ class QtPluginSorter(QWidget):
             self.info.hide()
             self.docstring.setToolTip('')
 
-    def refresh(self):
-        print("refresh", self.hook_combo_box.currentIndex())
+    def refresh(self, event=None):
         self._on_hook_change(self.hook_combo_box.currentIndex())
 
     def _on_disabled(self, event):
-        for i in range(self.hook_list.count() - 1):
+        for i in range(self.hook_list.count()):
             item = self.hook_list.item(i)
-            if item.hook_implementation.plugin_name == event.value:
+            if item and item.hook_implementation.plugin_name == event.value:
                 self.hook_list.takeItem(i)
 
     def value(self):

--- a/napari/_qt/widgets/qt_plugin_sorter.py
+++ b/napari/_qt/widgets/qt_plugin_sorter.py
@@ -301,8 +301,8 @@ class QtPluginSorter(QWidget):
         self.hook_combo_box.addItem(self.NULL_OPTION, None)
 
         # Included this, because I believe we want the plugin sorter to update from listening.
-        self.plugin_manager.events.disabled.connect(self._update)
-        self.plugin_manager.events.enabled.connect(self._update)
+        self.plugin_manager.events.disabled.connect(self._on_disabled)
+        # self.plugin_manager.events.enabled.connect(self._update)
 
         # populate comboBox with all of the hooks known by the plugin manager
 
@@ -395,8 +395,14 @@ class QtPluginSorter(QWidget):
             self.info.hide()
             self.docstring.setToolTip('')
 
-    def refresh(self):
+    def refresh(self, event=None):
         self._on_hook_change(self.hook_combo_box.currentIndex())
+
+    def _on_disabled(self, event):
+        for i in range(self.hook_list.count()):
+            item = self.hook_list.item(i)
+            if item.hook_implementation.plugin_name == event.value:
+                self.hook_list.takeItem(i)
 
     def value(self):
         """Returns the call order from the plugin manager.
@@ -408,8 +414,3 @@ class QtPluginSorter(QWidget):
         """
 
         return plugins.plugin_manager.call_order()
-
-    def _update(self, event):
-        # this refresh doesn't update right away.
-        print(event.value)
-        # self.refresh()


### PR DESCRIPTION
some suggestions...  General pattern here is that anything that knows about the plugin manager should update the plugin manager directly using it's API.  and anything that needs to show something about the plugin manager should be listening only to the plugin manager for events.  (we can extend this pattern back to call order in a future PR if needed).

I haven't had time to look yet, but I also found myself wondering what the new signals on the preferences dialog were for?

this _will_ currently break the call order preservation of a disabled plugin.  but I will explain that to everyone.  We need to accommodate that on the plugin manager model first